### PR TITLE
change schema PIN type to string

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -39,9 +39,9 @@
       },
       "pin": {
         "title": "Alarm PIN",
-        "type": "integer",
+        "type": "string",
         "required": true,
-        "default": 1234,
+        "default": "1234",
         "description": "Your local alarm PIN"
       },
       "openZoneTimeout": {


### PR DESCRIPTION
allows PINs with leading 0s to be used, avoiding command timeout / crash