### PR TITLE
Remove false opens

### DIFF
--- a/envisalink.js
+++ b/envisalink.js
@@ -460,11 +460,6 @@ class EnvisaLink {
           code: data
         };
 
-        // update zone information
-        if (mode != 'READY') {
-          zoneTimerOpen(tpi, zone);
-        }
-
         _this.emit('keypadupdate', {
           partition: partition,
           code: {


### PR DESCRIPTION
This code creates false opens in zones as it parses the USER/ZONE Field in a Virtual Keypad Update command as a zone update. This causes a false open (depending on the value in the hex field). Per the TPI programmer's guide, this argument may refer to a zone, but it doesn't constitute a zone open: http://forum.eyez-on.com/FORUM/download/file.php?id=224&sid=69c1d5b58d0f31b86430ed20892a9969 page 3/4.