### PR TITLE
added missing `this` to method call

### DIFF
--- a/accessories/partitionAccessory.js
+++ b/accessories/partitionAccessory.js
@@ -130,7 +130,7 @@ async getTargetState(callback) {
 processAlarmTimer() {
     if (this.processingAlarm) {
         this.log.warn(`Alarm request did not return successfully in allocated time. Current alarm status is ${this.envisakitCurrentStatus}`);
-        setAlarmState();
+        this.setAlarmState();
     } 
 }
 


### PR DESCRIPTION
Noticed the `setAlarmState` was missing a `this.`. Makes entire home bridge restart when alarm times out when arming/disarming.