### PR TITLE
Detect ARMED_NIGHT by looking at keypad_txt

### DIFF
--- a/envisalink.js
+++ b/envisalink.js
@@ -35,7 +35,7 @@ class EnvisaLink extends EventEmitter {
 
 
     if (config.sessionWatcher == undefined)
-    {  
+    {
       // If session watcher is enable auto-reconnection is also enabled.
       this.options.sessionwatcher = true;
       this.options.autoreconnect = true;
@@ -54,9 +54,9 @@ class EnvisaLink extends EventEmitter {
     this.isMaintenanceMode = config.maintenanceMode ? config.maintenanceMode: false
 
     // Set interval for testing connection and how long should zone should be consider without any update.
-    this.options.heartbeatInterval = Math.min(600,Math.max(10,config.heartbeatInterval));  
-    this.options.openZoneTimeout = Math.min(120,Math.max(5,config.openZoneTimeout));  
-    
+    this.options.heartbeatInterval = Math.min(600,Math.max(10,config.heartbeatInterval));
+    this.options.openZoneTimeout = Math.min(120,Math.max(5,config.openZoneTimeout));
+
     this.zones = {};
     this.lastmessage = new Date();
     this.lastsentcommand = "";
@@ -67,7 +67,7 @@ class EnvisaLink extends EventEmitter {
 
   }
 
-  
+
   startSession() {
 
     var self = this;
@@ -78,7 +78,7 @@ class EnvisaLink extends EventEmitter {
 
     // Display starting of connection.
     this.log.info(`Starting connection to envisalink module at: ${this.options.host}, port: ${this.options.port}`);
-   
+
     actual = net.createConnection({
       port: this.options.port,
       host: this.options.host
@@ -92,7 +92,7 @@ class EnvisaLink extends EventEmitter {
     actual.on('close', function (hadError) {
       self.isConnected = false;
       var source = "session_connect_status";
-      if (self.isConnectionIdleHandle !== undefined) 
+      if (self.isConnectionIdleHandle !== undefined)
       {
          clearTimeout(self.isConnectionIdleHandle);
       }
@@ -126,7 +126,7 @@ class EnvisaLink extends EventEmitter {
       for (var i = 0; i < dataslice.length; i++) {
         var datapacket = dataslice[i];
         if (datapacket !== '') {
-          
+
           if (datapacket.substring(0, 5) === 'Login') {
             self.log.debug("Login requested. Sending response " + self.options.password)
             self.isConnected = true;
@@ -136,7 +136,7 @@ class EnvisaLink extends EventEmitter {
             // The session will be closed
             self.isConnected = false;
           } else if (datapacket.substring(0, 2) === 'OK') {
-            // ignore, OK is good. or report successful connection.    
+            // ignore, OK is good. or report successful connection.
             self.log.info(`Successful TPI session established.`);
             // If connection had issue prior clear and generate restore event
             // Qualifier: 1 = Event, 3 = Restore
@@ -154,9 +154,9 @@ class EnvisaLink extends EventEmitter {
               self.log.info(`Checking for disconnected session every: ${self.options.heartbeatInterval} seconds.`)
               self.isConnectionIdleHandle = setTimeout( isConnectionIdle, (self.options.heartbeatInterval * 1000) ); // Check every idle seconds...
             }
-            else  
+            else
             {
-             self.log.warn("Warning: Session monitoring is disabled. Envisalink-Ademco will not watch for hung sessions.") 
+             self.log.warn("Warning: Session monitoring is disabled. Envisalink-Ademco will not watch for hung sessions.")
             }
           } else {
             var tpi_str = datapacket.match(/^%(.+)\$/); // pull out everything between the % and $
@@ -165,10 +165,10 @@ class EnvisaLink extends EventEmitter {
               if (tpi_str == null)
               {
                 self.log.warn("Envisalink data steam format invalid! : '" + datapacket + "'");
-              }  
+              }
               else
               {
-                if(self.lastsentcommand == tpi_str[1].split(',')[0]) 
+                if(self.lastsentcommand == tpi_str[1].split(',')[0])
                   self.log.info(`Envisakit module command return: ${tpidefs.command_response_codes[tpi_str[1].split(',')[1]]}`);
               }
 
@@ -235,16 +235,16 @@ class EnvisaLink extends EventEmitter {
       } else {
         // Connection not idle. Check again connection idle time seconds...
         self.log.debug("Heartbeat successful. Last message time: " + self.lastmessage)
-        self.isConnectionIdleHandle = setTimeout(isConnectionIdle, (self.options.heartbeatInterval * 1000)); 
+        self.isConnectionIdleHandle = setTimeout(isConnectionIdle, (self.options.heartbeatInterval * 1000));
       }
-    }; 
+    };
 
     function updateZone(tpi, data) {
       // now, what I need to do here is parse the data packet for parameters, in this case it's one parameter an
       // 8 byte HEX string little endian each bit represents a zone. If 1 the zone is active, 0 means not active.
       var zone_bits = data[1];
       // now, zone_bits should be a hex string, little_endian of zones represented by bits.
-      // need to loop through, byte by byte, figure out whats Bits are set and 
+      // need to loop through, byte by byte, figure out whats Bits are set and
       // return an array of active zones.
       // suggest finding the bits by taking a byte if it's not zero, do a modulo 2 on it, if the remainder is non-zero you have a bit
       // then shift the remaining bits right 1, and increment your bit index count by one.
@@ -256,7 +256,7 @@ class EnvisaLink extends EventEmitter {
         var byte = parseInt(zone_bits.substr(i, 2), 16); // get the two character hex byte value into an int
 
 
-        // since it's a byte, increment position by 8 bits, but since we're incrementing i by 2. for a 1 byte hex. 
+        // since it's a byte, increment position by 8 bits, but since we're incrementing i by 2. for a 1 byte hex.
         // we need to use a value of 4 to compensate. Then add 1, since we technically start counting our zones at 1, not zero. so but zero is zone 1.
         var position = (i * 4) + 1;
         // ( 64 - (14+2) * 4) + 1;
@@ -298,10 +298,10 @@ class EnvisaLink extends EventEmitter {
     }
 
     function updatePartition(tpi, data) {
-      // Unlike the code below, this Ademco panel sends an array of bytes, each one representing a partition and its state. 
+      // Unlike the code below, this Ademco panel sends an array of bytes, each one representing a partition and its state.
       // Example:
       // 0100010000000000
-      // so in the example above out of 8 partitions, partitions 1 and 3 are in state READY. 
+      // so in the example above out of 8 partitions, partitions 1 and 3 are in state READY.
       // There is a table you can refer to in section 3.4 of EnvisaLink  Vista TPI programmer's document that lists
       // the different values possible for each byte.
       var partition_string = data[1];
@@ -316,7 +316,7 @@ class EnvisaLink extends EventEmitter {
           code: byte,
           status: tpi.name
         });
-        
+
       }
     }
 
@@ -442,7 +442,7 @@ class EnvisaLink extends EventEmitter {
         }
       }
       if (activezones.length == 0) {
-        // Clean up 
+        // Clean up
         activeZoneTimeOut = undefined;
       } else {
         // Zones are still being track, set timer to review when next zone is scheduled to expire.
@@ -485,8 +485,8 @@ class EnvisaLink extends EventEmitter {
       return mode;
     }
 
-    function keyPadToHumanReadable(mode) {
-
+    function keyPadToHumanReadable(mode, keypad_txt) {
+      var is_night = keypad_txt.includes('NIGHT');
       var readableCode = 'NOT_READY';
       if (mode.alarm || mode.alarm_fire_zone) {
         readableCode = 'ALARM';
@@ -497,7 +497,7 @@ class EnvisaLink extends EventEmitter {
       } else if (mode.system_trouble && mode.ready) {
         readableCode = 'READY_SYSTEM_TROUBLE';
       } else if (mode.bypass && mode.armed_stay) {
-        readableCode = 'ARMED_STAY_BYPASS';
+        readableCode = is_night ? 'ARMED_NIGHT_BYPASS' : 'ARMED_STAY_BYPASS';
       } else if (mode.bypass && mode.armed_away) {
         readableCode = 'ARMED_AWAY_BYPASS';
       } else if (mode.bypass && mode.armed_zero_entry_delay) {
@@ -507,7 +507,7 @@ class EnvisaLink extends EventEmitter {
       } else if (mode.ready) {
         readableCode = 'READY';
       } else if (mode.armed_stay) {
-        readableCode = 'ARMED_STAY';
+        readableCode = is_night ? 'ARMED_NIGHT' : 'ARMED_STAY';
       } else if (mode.armed_away) {
         readableCode = 'ARMED_AWAY';
       } else if (mode.armed_zero_entry_delay) {
@@ -541,10 +541,10 @@ class EnvisaLink extends EventEmitter {
       // 00: ALARM (System is in Alarm)
       var ICON = data[2]; //two byte, HEX, representation of the bitfield.
       var keypadledstatus = getKeyPadLedStatus(data[2]);
-      var mode = keyPadToHumanReadable(keypadledstatus);
       var userOrZone = data[3]; // one byte field, representing extra info, either the user or the zone.
       var beep = tpidefs.virtual_keypad_beep[data[4]]; // information for the keypad on how to beep.
       var keypad_txt = data[5]; // 32 byte ascii string, a concat of 16 byte top and 16 byte bottom of display
+      var mode = keyPadToHumanReadable(keypadledstatus, keypad_txt);
       var icon_array = [];
       var position = 0; // Start at the right most position, Little endian 0.
 
@@ -558,32 +558,32 @@ class EnvisaLink extends EventEmitter {
       }
 
       self.alarmSystemMode = mode;
-      // Update zone information timer. 
+      // Update zone information timer.
       // Depending on the state of the update it will either represent a zone, or a user.
       // module makes assumption, if system is not-ready and panel text display "FAULT" assume zone is in fault.
-      
+
       if ((mode.substring(0, 9) == 'NOT_READY') && (keypad_txt.includes('FAULT')))
-      {    
+      {
         zoneTimerOpen(tpi, userOrZone);
       }
       // Check for a monitored zone
       if ((mode.substring(0, 9) == 'NOT_READY') && (keypad_txt.includes('CHECK')))
-      {    
+      {
         zoneTimerOpen(tpi, userOrZone);
       }
-      // System generate battery low event 
+      // System generate battery low event
       if((keypadledstatus.low_battery) && (keypad_txt.includes('LOBAT')))
       {
         zoneTimerOpen(tpi, userOrZone, "lowbatt.");
       }
 
       // bypass event reported to keypad
-      if((keypad_txt.substring(0, 5) == 'BYPAS') && (!keypadledstatus.not_used2) && ((mode == 'NOT_READY_BYPASS') || (mode == 'READY_BYPASS'))) 
+      if((keypad_txt.substring(0, 5) == 'BYPAS') && (!keypadledstatus.not_used2) && ((mode == 'NOT_READY_BYPASS') || (mode == 'READY_BYPASS')))
       {
         zoneTimerOpen(tpi, userOrZone, "bypassed.");
       }
 
-      // Generate event to update to update status 
+      // Generate event to update to update status
       self.emit('keypadupdate', {
         partition: partition,
         code: {
@@ -596,21 +596,21 @@ class EnvisaLink extends EventEmitter {
         keypadledstatus: keypadledstatus,
         mode: mode
       });
-      
+
     }
 
     function zoneTimeToHumanReadable(duration) {
       var hours = Math.floor(duration / 60 / 60);
       var minutes = Math.floor(duration / 60) - (hours * 60);
-      var seconds = duration % 60; 
+      var seconds = duration % 60;
       return hours.toString().padStart(2, '0') + 'h:' + minutes.toString().padStart(2, '0') + 'm:' + seconds.toString().padStart(2, '0') +'s';
     }
 
     function zoneTimerDump(tpi, data) {
       // Raw zone timers used inside the Envisalink.
       // The dump is a 256 character packed HEX string representing 64 UINT16
-      // (little endian) zone timers. Zone timers count down from 0xFFFF (zone is open) 
-      // to 0x0000 (zone is closed too long ago to remember). Each “tick” of he zone time 
+      // (little endian) zone timers. Zone timers count down from 0xFFFF (zone is open)
+      // to 0x0000 (zone is closed too long ago to remember). Each “tick” of he zone time
       // is actually 5 seconds so a zone timer of 0xFFFE means “5
       // seconds ago”. Remember, the zone timers are LITTLE ENDIAN so the
       // above example would be transmitted as FEFF.
@@ -631,7 +631,7 @@ class EnvisaLink extends EventEmitter {
           swappedBits = byte.substr(2, 4);
           swappedBits += byte.substr(0, 2);
           leZoneTimerDumpHexStr += swappedBits;
-          zoneClosedTimeCountDown = (MAXINT - parseInt(swappedBits.toString(),16)) * 5; 
+          zoneClosedTimeCountDown = (MAXINT - parseInt(swappedBits.toString(),16)) * 5;
           if (swappedBits == "FFFF")
           {
             zonesDumpData.push({
@@ -671,8 +671,8 @@ class EnvisaLink extends EventEmitter {
     }
 
     function cidEvent(tpi, data) {
-      // When a system event happens that is signaled to either the Envisalerts servers or the central monitoring station, 
-      // it is also presented through this command. The CID event differs from other TPI 
+      // When a system event happens that is signaled to either the Envisalerts servers or the central monitoring station,
+      // it is also presented through this command. The CID event differs from other TPI
       // commands as it is a binary coded decimal, not HEX.
       // QXXXPPZZZ0
       // Where:
@@ -701,7 +701,7 @@ class EnvisaLink extends EventEmitter {
       var partition = cid.substr(4, 2);
       var zone_or_user = cid.substr(6, 3);
       var cid_obj = ciddefs.cid_events_def[code];
-      
+
       var cidupdate_object = {
         partition: partition,
         qualifier: qualifier,
@@ -736,7 +736,7 @@ class EnvisaLink extends EventEmitter {
         this.log.error('Command not successful. No TPI session establish.');
         return false;
       }
-    } else 
+    } else
       this.log.warn('This module running in maintenance mode, command not sent.');
       return false;
   }

--- a/index.js
+++ b/index.js
@@ -428,15 +428,16 @@ class EnvisalinkPlatform {
                 if (partitionService) {
                     var targetState = partition.ENVISA_TO_HOMEKIT_CURRENT[data.mode];
 
-                    if(
-                        targetState === Characteristic.SecuritySystemTargetState.STAY_ARM &&
-                        partition.homekitLastTargetState === Characteristic.SecuritySystemTargetState.NIGHT_ARM
-                    ) {
-                        targetState = partition.homekitLastTargetState;
-                    }
-
-                    // if (partition.homekitLastTargetState != targetState) // XXX: temporarily removed the condition to resolve issue when disarming via Home app.
+                    if (partition.homekitLastTargetState != targetState)
                         {
+                            if (
+                                targetState === Characteristic.SecuritySystemTargetState.STAY_ARM &&
+                                partitionService.getCharacteristic(Characteristic.SecuritySystemTargetState).value === Characteristic.SecuritySystemTargetState.NIGHT_ARM
+                            ) {
+                                targetState = Characteristic.SecuritySystemTargetState.NIGHT_ARM;
+                            }
+
+
                             partitionService.updateCharacteristic(Characteristic.SecuritySystemCurrentState,targetState);
                             if(data.mode != 'ALARM') {
                                 partitionService.updateCharacteristic(Characteristic.SecuritySystemTargetState,targetState);

--- a/index.js
+++ b/index.js
@@ -43,8 +43,8 @@ class EnvisalinkPlatform {
             this.activeAccessoryMap = {};
             this.chime = config.chimeToggle ? config.chimeToggle: false;
             this.batteryRunTime = config.batteryRunTime ? config.batteryRunTime: 0;
-            this.commandTimeOut = Math.min(30,Math.max(1,config.commandTimeOut));  
-            // Should partition be changed when executing command? 
+            this.commandTimeOut = Math.min(30,Math.max(1,config.commandTimeOut));
+            // Should partition be changed when executing command?
             // Option only valid if this is a multiple partitions system
             this.changePartition = config.changePartition ? config.changePartition: false;
 
@@ -65,7 +65,7 @@ class EnvisalinkPlatform {
             // in order to ensure they weren't added to homebridge already. This event can also be used
              // to start discovery of new accessories.
             api.on('didFinishLaunching', () => {
-                // Create connection object 
+                // Create connection object
                 alarm = new elink(log, config);
                 // Build device list
                 this.log("Configuring", this.deviceDescription, "for Homekit...");
@@ -82,9 +82,9 @@ class EnvisalinkPlatform {
                 }
                 if (this.speedKeys.length > 0) this.log("Speed keys accessories configured.");
                 if (this.chime) this.log("Chime toggle accessory configured.")
-                
+
                 // Begin connection process and bind alarm events to local function.
-                // Should plug-in run in a disconnect mode. Allow maintenance without resulting in a lot of log errors 
+                // Should plug-in run in a disconnect mode. Allow maintenance without resulting in a lot of log errors
                 if (this.isMaintenanceMode == false){
                     // Start connection to Envisalink module
                     alarm.startSession();
@@ -93,14 +93,14 @@ class EnvisalinkPlatform {
                     alarm.on('zoneevent', this.zoneUpdate.bind(this));
                     alarm.on('updatepartition', this.partitionUpdate.bind(this));
                     alarm.on('cidupdate', this.cidUpdate.bind(this));
-                    
+
                     // Should module errors be suppress from homekit notification?
                     if (this.isEnvisalinkFailureSuppress == false) alarm.on('envisalinkupdate', this.envisalinkUpdate.bind(this));
                     else this.log.warn("No alarm Tamper will be generated for Envisalink communication failure. Please refer to your Homebridge logs for communication failures.");
-                
+
                     // Generate bypassed zone event to update the bypass accessories
                     setTimeout(function () {alarm.getBypassedZones(this.masterPin)}.bind(this),config.heartbeatInterval*1000);
-                   
+
                 }
                 else
                     this.log.warn("This plug-in is running in maintenance mode. All updates and operations are disabled!");
@@ -128,7 +128,7 @@ class EnvisalinkPlatform {
             }
             partition.model = this.deviceDescription + " Keypad";
             partition.deviceType =  this.deviceType;
-            // set command timeout 
+            // set command timeout
             partition.commandTimeOut = this.commandTimeOut;
             partition.batteryRunTime = this.batteryRunTime * 60 * 60;
             partition.changePartition = this.changePartition;
@@ -151,9 +151,9 @@ class EnvisalinkPlatform {
                 this.addAccessory(partitionAccessory);
             }
             else { // accessory already exist just set characteristic
-                partitionAccessory.setAccessory(foundAccessory); 
+                partitionAccessory.setAccessory(foundAccessory);
             }
-            // Add to active accessory list, which is later used to remove unused cache entries  
+            // Add to active accessory list, which is later used to remove unused cache entries
             this.activeAccessoryMap[partitionAccessory.uuid] = true;
 
             var partitionIndex =  this.platformPartitionAccessories.push(partitionAccessory) - 1;
@@ -175,9 +175,9 @@ class EnvisalinkPlatform {
                 }
                 zone.model = this.deviceDescription + " " + zone.sensorType.charAt(0).toUpperCase() + zone.sensorType.slice(1) + " sensor";
                 zone.serialNumber = "envisalink." + zone.sensorType + "."+ zone.partition + "." + zoneNum;
-                if (this.bypass.length > 0) 
-                    zone.masterBypass = this.bypass[0].enabledbyPass; 
-                else    
+                if (this.bypass.length > 0)
+                    zone.masterBypass = this.bypass[0].enabledbyPass;
+                else
                     zone.masterBypass = false;
                 zone.pin = this.masterPin;
                 zone.commandTimeOut = this.commandTimeOut;
@@ -194,7 +194,7 @@ class EnvisalinkPlatform {
                     this.addAccessory(zoneAccessory);
                 }
                 else { // accessory already exist just set characteristic
-                    zoneAccessory.setAccessory(foundAccessory); 
+                    zoneAccessory.setAccessory(foundAccessory);
                 }
                 // Add to active accessory list, which is later used to remove unused cache entries
                 this.activeAccessoryMap[zoneAccessory.uuid] = true;
@@ -202,7 +202,7 @@ class EnvisalinkPlatform {
                 var accessoryIndex = this.platformZoneAccessories.push(zoneAccessory) - 1;
                 this.platformZoneAccessoryMap['z.' + zoneNum] = accessoryIndex;
                 this.log.debug("refreshAccessories: Zone number - ", zoneNum , " configured.");
-            } else 
+            } else
                 this.log.error("Misconfigured zone definition " + zone.name + ". Entry - " + i + " ignoring.");
          }
 
@@ -211,7 +211,7 @@ class EnvisalinkPlatform {
      // Create associates custom in Homekit based on configuration file
     refreshCustomAccessories() {
 
-        // Process toggle chime switch functionality 
+        // Process toggle chime switch functionality
         if (this.chime ) {
             var chimeswitch = {};
             chimeswitch.pin = this.masterPin;
@@ -234,7 +234,7 @@ class EnvisalinkPlatform {
             }
             else {// accessory already exist just set characteristic
                 customAccessory.setAccessory(foundAccessory);
-                
+
             }
             // Add to active accessory list, which is later used to remove unused cache entries
             this.activeAccessoryMap[customAccessory.uuid] = true;
@@ -254,7 +254,7 @@ class EnvisalinkPlatform {
                 bypassswitch.serialNumber = "envisalink.bypass.all";
                 bypassswitch.commandTimeOut = this.commandTimeOut;
                 bypassswitch.zoneDevices  = this.platformZoneAccessories;
-            
+
                 // Create bypass switch
                 var customAccessory = new customDevices(this.log, bypassswitch, Service, Characteristic, UUIDGen, alarm);
                 // check the accessory was not restored from cache
@@ -277,7 +277,7 @@ class EnvisalinkPlatform {
             }
         }
 
-        // Creating macro/speed keys 
+        // Creating macro/speed keys
         if (this.speedKeys.length > 0) {
             var speedkey = [];
             speedkey.pin = this.masterPin;
@@ -326,7 +326,7 @@ class EnvisalinkPlatform {
                             {
                                 if(data.qualifier == 1) partitionService.updateCharacteristic(Characteristic.StatusFault,Characteristic.StatusTampered.TAMPERED);
                                 if(data.qualifier == 3) partitionService.updateCharacteristic(Characteristic.StatusFault,Characteristic.StatusTampered.NOT_TAMPERED);
-                             
+
                            }
                         break;
                     }
@@ -347,28 +347,28 @@ class EnvisalinkPlatform {
                 if ((partition.processingAlarm == false) && (partition.accessoryType == "partition")) {
                     if ((partition.envisakitCurrentStatus != data.mode)) {
                         partition.envisakitCurrentStatus = data.mode;
-                        
+
                         this.log.debug("systemUpdate: partition change - " + partition.name + ' to ' + partition.envisakitCurrentStatus);
                         const partitionService = partition.accessory.getService(Service.SecuritySystem);
                         if (partitionService) {
                             if (partition.homekitLastTargetState != partition.ENVISA_TO_HOMEKIT_TARGET[data.mode])
                                 {
-                                    
+
                                     partitionService.updateCharacteristic(Characteristic.SecuritySystemCurrentState,partition.ENVISA_TO_HOMEKIT_CURRENT[data.mode]);
                                     if(data.mode != 'ALARM') {
-                                        partitionService.updateCharacteristic(Characteristic.SecuritySystemTargetState,partition.ENVISA_TO_HOMEKIT_TARGET[data.mode]);  
+                                        partitionService.updateCharacteristic(Characteristic.SecuritySystemTargetState,partition.ENVISA_TO_HOMEKIT_TARGET[data.mode]);
                                         partition.homekitLastTargetState = partition.ENVISA_TO_HOMEKIT_TARGET[data.mode];
                                     }
-                                }       
+                                }
                             // if system is not ready or has a fault set general fault
-                            if (partition.envisakitCurrentStatus.includes('NOT_READY') || partition.envisakitCurrentStatus.includes('ALARM_MEMORY') || partition.envisakitCurrentStatus.includes('READY_FIRE_TROUBLE') || partition.envisakitCurrentStatus.includes('READY_SYSTEM_TROUBLE')) partitionService.updateCharacteristic(Characteristic.StatusFault,Characteristic.StatusFault.GENERAL_FAULT); 
+                            if (partition.envisakitCurrentStatus.includes('NOT_READY') || partition.envisakitCurrentStatus.includes('ALARM_MEMORY') || partition.envisakitCurrentStatus.includes('READY_FIRE_TROUBLE') || partition.envisakitCurrentStatus.includes('READY_SYSTEM_TROUBLE')) partitionService.updateCharacteristic(Characteristic.StatusFault,Characteristic.StatusFault.GENERAL_FAULT);
                             else partitionService.updateCharacteristic(Characteristic.StatusFault,Characteristic.StatusFault.NO_FAULT);
                         }
-                    }                 
+                    }
                 }
             }
         } else {
-            this.log("System status reported: Partition is not monitored, dismissing status update."); 
+            this.log("System status reported: Partition is not monitored, dismissing status update.");
         }
 
         // if chime enable update status;
@@ -403,16 +403,16 @@ class EnvisalinkPlatform {
                     }
                 }
             }
-        } 
+        }
 
         // Check if panel is on battery power (loss power)
         if(!data.keypadledstatus.ac_present){
             if(partition.ChargingState == Characteristic.ChargingState.CHARGING) {
-                partition.ChargingState = Characteristic.ChargingState.NOT_CHARGING; 
-                partition.downTime = new Date(); 
+                partition.ChargingState = Characteristic.ChargingState.NOT_CHARGING;
+                partition.downTime = new Date();
             }
         } else partition.ChargingState = Characteristic.ChargingState.CHARGING;
-        
+
     }
 
     // Capture partition updates usually associated with arm, disarm events
@@ -426,20 +426,29 @@ class EnvisalinkPlatform {
                 this.log.debug("partitionUpdate: Partition data - " + partition.name + ' to ' + partition.envisakitCurrentStatus);
                 const partitionService = partition.accessory.getService(Service.SecuritySystem);
                 if (partitionService) {
-                    if (partition.homekitLastTargetState != partition.ENVISA_TO_HOMEKIT_TARGET[data.mode])
+                    var targetState = partition.ENVISA_TO_HOMEKIT_CURRENT[data.mode];
+
+                    if(
+                        targetState === Characteristic.SecuritySystemTargetState.STAY_ARM &&
+                        partition.homekitLastTargetState === Characteristic.SecuritySystemTargetState.NIGHT_ARM
+                    ) {
+                        targetState = partition.homekitLastTargetState;
+                    }
+
+                    // if (partition.homekitLastTargetState != targetState) // XXX: temporarily removed the condition to resolve issue when disarming via Home app.
                         {
-                            partitionService.updateCharacteristic(Characteristic.SecuritySystemCurrentState,partition.ENVISA_TO_HOMEKIT_CURRENT[data.mode]);
+                            partitionService.updateCharacteristic(Characteristic.SecuritySystemCurrentState,targetState);
                             if(data.mode != 'ALARM') {
-                                partitionService.updateCharacteristic(Characteristic.SecuritySystemTargetState,partition.ENVISA_TO_HOMEKIT_TARGET[data.mode]);  
+                                partitionService.updateCharacteristic(Characteristic.SecuritySystemTargetState,targetState);
                                 partition.homekitLastTargetState = partition.ENVISA_TO_HOMEKIT_TARGET[data.mode];
                             }
-                        }       
+                        }
                     // if system is not ready set general fault
-                    if (partition.envisakitCurrentStatus.includes('NOT_READY') || partition.envisakitCurrentStatus.includes('ALARM_MEMORY')) partitionService.updateCharacteristic(Characteristic.StatusFault,Characteristic.StatusFault.GENERAL_FAULT); 
+                    if (partition.envisakitCurrentStatus.includes('NOT_READY') || partition.envisakitCurrentStatus.includes('ALARM_MEMORY')) partitionService.updateCharacteristic(Characteristic.StatusFault,Characteristic.StatusFault.GENERAL_FAULT);
                     else partitionService.updateCharacteristic(Characteristic.StatusFault,Characteristic.StatusFault.NO_FAULT);
                 }
                 if (partition.processingAlarm) {
-                    // clear timer 
+                    // clear timer
                     partition.processingAlarm = false;
                     clearTimeout(partition.armingTimeOut);
                     partition.armingTimeOut = undefined;
@@ -447,7 +456,7 @@ class EnvisalinkPlatform {
             }
         }
         else {
-            this.log.debug("Partition status change: Partition not monitored dismissing partition update. "); 
+            this.log.debug("Partition status change: Partition not monitored dismissing partition update. ");
         }
     }
     // Capture zone updates usually associated sensor going from open to close and vice-versa
@@ -463,29 +472,29 @@ class EnvisalinkPlatform {
                 switch(zoneaccessory.sensorType) {
                     case "motion":
                     case "glass":
-                        if (accessoryService) accessoryService.getCharacteristic(Characteristic.MotionDetected).setValue(zoneaccessory.ENVISA_TO_HOMEKIT_MOTION[data.mode]);  
+                        if (accessoryService) accessoryService.getCharacteristic(Characteristic.MotionDetected).setValue(zoneaccessory.ENVISA_TO_HOMEKIT_MOTION[data.mode]);
                     break;
 
                     case "door":
                     case "window":
-                        if (accessoryService) accessoryService.getCharacteristic(Characteristic.ContactSensorState).setValue(zoneaccessory.ENVISA_TO_HOMEKIT_CONTACT[data.mode]);  
+                        if (accessoryService) accessoryService.getCharacteristic(Characteristic.ContactSensorState).setValue(zoneaccessory.ENVISA_TO_HOMEKIT_CONTACT[data.mode]);
                     break;
 
                     case "leak":
-                        if (accessoryService) accessoryService.getCharacteristic(Characteristic.LeakDetected).setValue(zoneaccessory.ENVISA_TO_HOMEKIT_LEAK[data.mode]);  
+                        if (accessoryService) accessoryService.getCharacteristic(Characteristic.LeakDetected).setValue(zoneaccessory.ENVISA_TO_HOMEKIT_LEAK[data.mode]);
                     break;
 
                     case "smoke":
-                        if (accessoryService) accessoryService.getCharacteristic(Characteristic.SmokeDetected).setValue(zoneaccessory.ENVISA_TO_HOMEKIT_SMOKE[data.mode]);  
+                        if (accessoryService) accessoryService.getCharacteristic(Characteristic.SmokeDetected).setValue(zoneaccessory.ENVISA_TO_HOMEKIT_SMOKE[data.mode]);
                     break;
 
                     case "co":
-                        if (accessoryService) accessoryService.getCharacteristic(Characteristic.CarbonMonoxideDetected).setValue(zoneaccessory.ENVISA_TO_HOMEKIT_CO[data.mode]); 
+                        if (accessoryService) accessoryService.getCharacteristic(Characteristic.CarbonMonoxideDetected).setValue(zoneaccessory.ENVISA_TO_HOMEKIT_CO[data.mode]);
                     break;
                 }
-                
+
             }
-        } 
+        }
     }
 
     // Capture low level updates that are not generate from keypad events, but sent to monitoring station.
@@ -499,7 +508,7 @@ class EnvisalinkPlatform {
                 var accessory = this.platformZoneAccessories[accessoryIndex];
                 var accessoryService = accessory.service;
                 this.log.debug(`cidUpdate: Accessory change - Zone: ${data.zone} Name: ${accessory.name} Code: ${data.code} Qualifier: ${data.qualifier}.`);
-                switch (Number(data.code)) { 
+                switch (Number(data.code)) {
 
                     case 150: //Alarm, 24-Hour Auxiliar
                         if(data.qualifier == 1) accessoryService.updateCharacteristic(Characteristic.StatusFault, Characteristic.StatusFault.GENERAL_FAULT);
@@ -518,7 +527,7 @@ class EnvisalinkPlatform {
 
                     // qualifier can be 1 = 'Event or Opening', 3 = 'Restore or Closing'
                     case 570:  // Bypass event
-                        if(data.qualifier == 1){ 
+                        if(data.qualifier == 1){
                             this.log(`${accessory.name} has been bypass.`);
                             accessory.bypassStatus = true;
                         }
@@ -527,14 +536,14 @@ class EnvisalinkPlatform {
                             accessory.bypassStatus = false;
                         }
                         alarm.isProcessingBypassqueue = alarm.isProcessingBypassqueue - 1;
-                        if ((alarm.isProcessingBypassqueue <= 0 ) && (alarm.isProcessingBypass)) { 
-                            alarm.isProcessingBypass = false; 
+                        if ((alarm.isProcessingBypassqueue <= 0 ) && (alarm.isProcessingBypass)) {
+                            alarm.isProcessingBypass = false;
                             alarm.isProcessingBypassqueue = 0;
                             this.log(`All queued bypass/un-bypass command(s) completed.`)
                         }
                     break;
 
-                    
+
                 }
             }
         }
@@ -547,10 +556,10 @@ class EnvisalinkPlatform {
                 switch (Number(data.code)) {
                     case 301: // Trouble-AC Power
                         if((data.qualifier == 1) && (partition.ChargingState == Characteristic.ChargingState.CHARGING)) {
-                            partition.ChargingState = Characteristic.ChargingState.NOT_CHARGING; 
-                            partition.downTime = new Date(); 
+                            partition.ChargingState = Characteristic.ChargingState.NOT_CHARGING;
+                            partition.downTime = new Date();
                         }
-                        if(data.qualifier == 3) partition.ChargingState = Characteristic.ChargingState.CHARGING; 
+                        if(data.qualifier == 3) partition.ChargingState = Characteristic.ChargingState.CHARGING;
                     break;
 
                     case 302: // Trouble-Low Battery (AC is lost, battery is getting low)
@@ -558,7 +567,7 @@ class EnvisalinkPlatform {
                             if (partition.batteryLevel > 20) partition.batteryLevel = 20;
                         if(data.qualifier == 3) partition.batteryLevel = 100;
                         var partitionServiceBattery = partition.getService(Service.Battery);
-                        if (partitionServiceBattery) partitionServiceBattery.updateCharacteristic(Characteristic.BatteryLevel,partition.batteryLevel); 
+                        if (partitionServiceBattery) partitionServiceBattery.updateCharacteristic(Characteristic.BatteryLevel,partition.batteryLevel);
                     break;
 
                     case 309: // Trouble-Battery Test Failure (Battery failed at test interval)
@@ -567,10 +576,10 @@ class EnvisalinkPlatform {
                             partition.batteryLevel = 0;
                         if(data.qualifier == 3) partition.batteryLevel = 100;
                         var partitionService = partition.accessory.getService(Service.SecuritySystem);
-                        if (partitionService) partitionService.updateCharacteristic(Characteristic.BatteryLevel,partition.batteryLevel); 
+                        if (partitionService) partitionService.updateCharacteristic(Characteristic.BatteryLevel,partition.batteryLevel);
                     break;
 
-                    case 144: // Alarm-Sensor Tamper-# 
+                    case 144: // Alarm-Sensor Tamper-#
                     case 145: // Alarm-Exp. Module Tamper-#
                     case 137: // Burg-Tamper-#
                     case 316: // Trouble System Tamper
@@ -589,8 +598,8 @@ class EnvisalinkPlatform {
     removeOrphanAccessory() {
         var cachedAccessory = this.accessories;
         var foundAccessory;
-        for (var i = 0; i < cachedAccessory.length; i++) 
-        {   
+        for (var i = 0; i < cachedAccessory.length; i++)
+        {
             let accessory = cachedAccessory[i];
             foundAccessory = this.activeAccessoryMap[accessory.UUID];
             if (foundAccessory == undefined) {
@@ -641,5 +650,5 @@ const homebridge = homebridge => {
     UUIDGen = homebridge.hap.uuid;
     homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, EnvisalinkPlatform);
 };
-  
+
 module.exports = homebridge;


### PR DESCRIPTION
It's known the envisalink doesn't properly report on on NIGHT STAY. Looks like the plugin will look for `mode.armed_zero_entry_delay` to detect night stay, but this is not always reliable. My system for example is a SIA system, so `mode.armed_zero_entry_delay` is always false (it's a regulatory thing on certain states, and it's hardcoded on my firmware, can't disable it). For this reason I **can** set it as NIGHT but it will **always report back** to HomeKit as HOME, making it automatically switch to Home mode.

One idea to detect NIGHT stay is looking for the word NIGH on the text returned by the keypad update and assume it's armed in NIGHT mode. It's not perfect but worked fine on my tests. I'll add some comments to the code explaining some of it.

PS: there's a bunch of whitespace that got removed automatically, make sure to ignore whitespaces when looking at the diff.