### PR TITLE
fix: clear zone bypass status on disarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/).
+# v2.1.2 (2026-02-07)
+## Break fixes
+* Fix HomeKit bypass switch not clearing on disarm. The panel silently clears all zone bypasses on disarm without sending per-zone CID events, so bypass state is now cleared in `partitionUpdate` when a disarmed mode is detected.
+
 # v2.1.1 (2025-09-17) 
 ## Enhancements
 * Add support to forward Envisalink web console connection to the actual Envisalink console web portal.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-envisalink-ademco",
-  "version": "2.0.0",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-envisalink-ademco",
-      "version": "2.0.0",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "net": ">=1.0.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-envisalink-ademco",
   "displayName": "Homebridge Envisalink Ademco",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "description": "Homebridge Plug-in Envisalink for Ademco/Honeywell",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## Problem

When a zone is bypassed via the iOS bypass switch and then the alarm is armed and subsequently disarmed, the Ademco panel automatically clears all zone bypasses on disarm. However, the HomeKit Switch characteristic is **never updated** -- so the iOS switch remains showing "on" even though the zone is no longer bypassed on the physical panel.

Additionally, attempting to toggle the bypass switch off manually after disarm results in errors because the plugin thinks it's still processing a bypass request:

```
[07/02/2026, 12:10:41] [Envisalink-Ademco] Disarming the alarm system with PIN, [Partition 1].
[07/02/2026, 12:13:01] [Envisalink-Ademco] Removing bypassing of Back Door ...
[07/02/2026, 12:13:03] [Envisalink-Ademco] Already processing Bypass request. Command ignored.
[07/02/2026, 12:13:03] [Envisalink-Ademco] Already processing Bypass request. Command ignored.
[07/02/2026, 12:13:03] [Envisalink-Ademco] Already processing Bypass request. Command ignored.
[07/02/2026, 12:13:11] [Envisalink-Ademco] Bypass request did not return successfully in the allocated time
```

You otherwise have to reboot the homebridge or child bridge instance to clear this

### Steps to Reproduce

1. Bypass a zone (e.g., Back Door) using the iOS bypass switch
2. Arm the alarm in iOS
3. Disarm the alarm in iOS
4. Observe the iOS bypass switch is still set to "on", but the alarm panel shows the zone is no longer bypassed
5. A homebridge/child bridge after disarm resets the button state

## Root Cause

The Ademco panel clears all zone bypasses on disarm but does **not** send individual CID 570 (ZONE_BYPASS) qualifier 3 (Restore) events per zone. The original code only handled bypass state changes via CID 570 events, which never fire in this scenario.

## Changes

### 1. Clear bypass switches on disarm (`partitionUpdate` method) -- **the primary fix**

When a `partitionUpdate` event indicates the system has transitioned to a disarmed state (`READY`, `NOT_READY`, etc.), the plugin now iterates through all zone accessories and clears `bypassStatus` and updates the HomeKit Switch characteristic for any zone that was bypassed.

### 2. Update Switch characteristic on CID 570 events (`cidUpdate` method)

Added `updateCharacteristic` calls in the `cidUpdate` method's `case 570` block for both qualifier 1 (bypass confirmed) and qualifier 3 (restore/un-bypass). This handles the case where the panel does send explicit per-zone bypass CID events. Follows the existing pattern used for tamper, battery, and chime status updates elsewhere in the file.

**Note:** Testing confirmed the panel does **not** send CID 570 qualifier 3 on disarm, so this alone is insufficient -- but it provides belt-and-suspenders coverage if the panel sends these events in other scenarios.

## Verification

Tested on a live Honeywell VISTA panel with Envisalink module. After applying the fix, disarming correctly clears the bypass switch in HomeKit:

```
[07/02/2026, 12:14:40] [Envisalink-Ademco] Disarming the alarm system with PIN, [Partition 1].
[07/02/2026, 12:14:42] [Envisalink-Ademco] Back Door bypass cleared on disarm.
```